### PR TITLE
Bug fix for failing tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,44 @@
 calico-node-*.tar
+# First, ignore yourself.
+.gitignore
+
+# Files created by ./bootstrap.
+.reviewboardrc
+Makefile.in
+aclocal.m4
+ar-lib
+autom4te.cache
+compile
+config.guess
+config.sub
+configure
+depcomp
+install-sh
+libtool.m4
+ltmain.sh
+ltoptions.m4
+ltsugar.m4
+ltversion.m4
+lt~obsolete.m4
+missing
+
+*.pyc
+
+# Recommended build directory.
+/build/
+
+# OSX Resource
+.DS_Store
+
+# CTags
+.tags
+.tags_sorted_by_file
+
+# Sublime
+*.sublime-project
+*.sublime-workspace
+
+# CLion
+.idea
+CMakeLists.txt
+.reviewboardrc


### PR DESCRIPTION
I verified it locally and the app seems to be running fine. However, I ge the following error after running `test/run_compose_st.sh`:

```
Traceback (most recent call last):
  File "get_ip_on_app.py", line 37, in <module>
    slave_id = get_slave_id(data, slave_name)
  File "get_ip_on_app.py", line 22, in get_slave_id
    raise Exception("Couldn't find a slave with name: %s" % slave_name)
Exception: Couldn't find a slave with name: slave1
Error response from daemon: no such id: modules_slave1_1
Traceback (most recent call last):
  File "get_ip_on_app.py", line 37, in <module>
    slave_id = get_slave_id(data, slave_name)
  File "get_ip_on_app.py", line 22, in get_slave_id
    raise Exception("Couldn't find a slave with name: %s" % slave_name)
Exception: Couldn't find a slave with name: slave2
Error response from daemon: no such id: modules_slave2_1
Traceback (most recent call last):
  File "get_app_on_slave.py", line 37, in <module>
    slave_id = get_slave_id(data, slave_name)
  File "get_app_on_slave.py", line 22, in get_slave_id
    raise Exception("Couldn't find a slave with name: %s" % slave_name)
Exception: Couldn't find a slave with name: slave1
Error response from daemon: no such id: modules_slave1_1
Traceback (most recent call last):
  File "get_app_on_slave.py", line 37, in <module>
    slave_id = get_slave_id(data, slave_name)
  File "get_app_on_slave.py", line 22, in get_slave_id
    raise Exception("Couldn't find a slave with name: %s" % slave_name)
Exception: Couldn't find a slave with name: slave2
Error response from daemon: no such id: modules_slave2_1
./test/run_compose_st.sh took 191.511040 seconds
```
